### PR TITLE
2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitchapi.js",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "devDependencies": {
     "typedoc": "^0.23.23",
     "typescript": "^4.9.4"

--- a/src/sockets/eventsub/addToSocketViewer.ts
+++ b/src/sockets/eventsub/addToSocketViewer.ts
@@ -10,7 +10,6 @@ export class AddToSocketViewer extends BaseSocket{
             console.log("add " + intent + "websocket")
             let version = 1;
             if (intent === Intents.Intents.ChannelFollow){
-                console.log("CHANNEL FOLLOW V2")
                 version = 2;
             }
             await axios.post(


### PR DESCRIPTION
changelogs version 2.0.4
```
Patch bug with channel.follow beacause using api version 2
Patch bug of types ( all of Intents is not correctly registered)
Remove ommit debug (console.log() line 13
```
Add the possibility to import Intent with
```js

import {twitchapi, Intents} from "./twitch-api.js/src/twitchapi";
```